### PR TITLE
Add simple login form

### DIFF
--- a/CommunTools/Common/UserSession.cs
+++ b/CommunTools/Common/UserSession.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using CommunTools.Enums;
+
+namespace CommunTools.Common
+{
+    /// <summary>
+    /// 管理登录用户信息
+    /// </summary>
+    public static class UserSession
+    {
+        private static readonly Dictionary<string, (string Password, UserRole Role)> _users =
+            new Dictionary<string, (string, UserRole)>()
+            {
+                { "admin", ("admin", UserRole.Admin) },
+                { "user", ("user", UserRole.User) }
+            };
+
+        public static string UserName { get; private set; } = string.Empty;
+        public static UserRole Role { get; private set; } = UserRole.Guest;
+
+        public static bool Login(string name, string password)
+        {
+            if (_users.TryGetValue(name, out var info) && info.Password == password)
+            {
+                UserName = name;
+                Role = info.Role;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/CommunTools/CommunTools.csproj
+++ b/CommunTools/CommunTools.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Common\Twain\TwainGui.cs" />
     <Compile Include="Common\Twain\TwainLib.cs" />
     <Compile Include="Common\Twain\TwainScanCommon.cs" />
+    <Compile Include="Common\UserSession.cs" />
     <Compile Include="Entity\TCPClient.cs" />
     <Compile Include="Entity\TCPComServer.cs" />
     <Compile Include="Entity\TCPServer.cs" />
@@ -78,6 +79,7 @@
     <Compile Include="Enums\Encoding.cs" />
     <Compile Include="Enums\FuncItemCom.cs" />
     <Compile Include="Enums\SerialPortEnum.cs" />
+    <Compile Include="Enums\UserRole.cs" />
     <Compile Include="FrmBaseCom\Frm_ComLPT.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -137,6 +139,9 @@
     </Compile>
     <Compile Include="FrmBaseCom\Frm_TCPClient.Designer.cs">
       <DependentUpon>Frm_TCPClient.cs</DependentUpon>
+    </Compile>
+    <Compile Include="FrmLogin.cs">
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CommunTools/Enums/UserRole.cs
+++ b/CommunTools/Enums/UserRole.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+
+namespace CommunTools.Enums
+{
+    /// <summary>
+    /// 用户权限级别
+    /// </summary>
+    public enum UserRole
+    {
+        [Description("访客")]
+        Guest = 0,
+        [Description("普通用户")]
+        User = 1,
+        [Description("管理员")]
+        Admin = 2
+    }
+}

--- a/CommunTools/FrmLogin.cs
+++ b/CommunTools/FrmLogin.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Com_CSSkin;
+using CommunTools.Common;
+
+namespace CommunTools
+{
+    /// <summary>
+    /// 登录界面
+    /// </summary>
+    public class FrmLogin : CSSkinMain
+    {
+        private TextBox txtUser;
+        private TextBox txtPwd;
+        private Button btnOk;
+        private Button btnCancel;
+
+        public FrmLogin()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            this.txtUser = new TextBox();
+            this.txtPwd = new TextBox();
+            this.btnOk = new Button();
+            this.btnCancel = new Button();
+            this.SuspendLayout();
+            // 
+            // txtUser
+            // 
+            this.txtUser.Location = new Point(80, 25);
+            this.txtUser.Size = new Size(150, 21);
+            // 
+            // txtPwd
+            // 
+            this.txtPwd.Location = new Point(80, 60);
+            this.txtPwd.Size = new Size(150, 21);
+            this.txtPwd.PasswordChar = '*';
+            // 
+            // btnOk
+            // 
+            this.btnOk.Location = new Point(40, 100);
+            this.btnOk.Size = new Size(75, 23);
+            this.btnOk.Text = "登录";
+            this.btnOk.Click += new EventHandler(this.btnOk_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new Point(140, 100);
+            this.btnCancel.Size = new Size(75, 23);
+            this.btnCancel.Text = "取消";
+            this.btnCancel.Click += (s, e) => this.Close();
+            // 
+            // FrmLogin
+            // 
+            this.AutoScaleMode = AutoScaleMode.None;
+            this.ClientSize = new Size(260, 150);
+            this.Controls.Add(new Label { Text = "用户", Location = new Point(30, 28), AutoSize = true });
+            this.Controls.Add(this.txtUser);
+            this.Controls.Add(new Label { Text = "密码", Location = new Point(30, 63), AutoSize = true });
+            this.Controls.Add(this.txtPwd);
+            this.Controls.Add(this.btnOk);
+            this.Controls.Add(this.btnCancel);
+            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.StartPosition = FormStartPosition.CenterScreen;
+            this.Text = "用户登录";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            if (UserSession.Login(txtUser.Text.Trim(), txtPwd.Text))
+            {
+                this.DialogResult = DialogResult.OK;
+            }
+            else
+            {
+                MessageBox.Show("用户名或密码错误");
+            }
+        }
+    }
+}

--- a/CommunTools/FrmMenu.cs
+++ b/CommunTools/FrmMenu.cs
@@ -40,6 +40,7 @@ namespace CommunTools
         private void FrmMenu_Load(object sender, EventArgs e)
         {
             GetMenuGroup();
+            this.Text = $"硬件及协议通讯工具 - {Common.UserSession.UserName}({Common.UserSession.Role})";
 
             int gpbIndex = 0;
             int totolHeight = 0;

--- a/CommunTools/Program.cs
+++ b/CommunTools/Program.cs
@@ -15,7 +15,13 @@ namespace CommunTools
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new FrmMenu());
+            using (FrmLogin login = new FrmLogin())
+            {
+                if (login.ShowDialog() == DialogResult.OK)
+                {
+                    Application.Run(new FrmMenu());
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `UserRole` enum for login permission levels
- implement `UserSession` to manage users and roles
- create `FrmLogin` form for username/password login
- require login before showing main menu
- display logged-in user info in menu title

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491d75aa0c8331a2342973261d1a58